### PR TITLE
Removed two define-key expressions of ox-batch-mode-map

### DIFF
--- a/ox-mode.el
+++ b/ox-mode.el
@@ -189,8 +189,6 @@ Each list item should be a regexp matching a single identifier." :group 'ox)
   (define-key ox-mode-map (kbd "C-c p") 'ox-parse)
   (define-key ox-mode-map (kbd "C-c u") 'uncomment-region)
   (define-key ox-mode-map (kbd "C-c c") 'comment-region)
-  (define-key ox-batch-mode-map (kbd "C-c C-c") 'comment-region)
-  (define-key ox-batch-mode-map (kbd "C-c C-u") 'uncomment-region)
 ;; Debugging commands (optional keybindings)
 ;; (I'll straighten out these keybindings when we upgrade debugging
 ;; support next)


### PR DESCRIPTION
No declaration of ox-batch-mode-map before these expressions, and the same expressions are in line 293 and 294 in the original file. These made the error "**Symbol's value as variable is void: ox-batch-mode-map**".